### PR TITLE
Feature: Hide doc nav icon if page not existent

### DIFF
--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -1,7 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
     const currentUrl = window.location.href;
     document.querySelector(".nav-list").style.display = 'block'
-
     // check if we are in the user guid tabs
     if (currentUrl.includes('user_guide')) {
         const parts = currentUrl.split('/');
@@ -22,10 +21,17 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
         
-        console.log('execute')
+        // Remove the logo of the portal from the nav if it doesn't have the current page
+        const nav_links = document.getElementById('ontoportal_tabs').querySelectorAll('a')
+        for(let i = 0; i<nav_links.length; i++){
+            fetch(nav_links[i].href)
+            .then(response => {
+                if (response.status === 404) {
+                    nav_links[i].remove()
+                }
+            });
+        }
     } else {
         document.querySelector(".breadcrumb-nav").style.display = 'block'
-        
     }
-
 });

--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -22,15 +22,16 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         
         // Remove the logo of the portal from the nav if it doesn't have the current page
-        const nav_links = document.getElementById('ontoportal_tabs').querySelectorAll('a')
-        for(let i = 0; i<nav_links.length; i++){
-            fetch(nav_links[i].href)
-            .then(response => {
-                if (response.status === 404) {
-                    nav_links[i].remove()
-                }
-            });
-        }
+        const navLinks = Array.from(document.getElementById('ontoportal_tabs').querySelectorAll('a'));
+        navLinks.forEach(navLink => {
+            fetch(navLink.href)
+                .then(response => {
+                    if (response.status === 404) {
+                        navLink.remove();
+                    }
+                });
+        });
+
     } else {
         document.querySelector(".breadcrumb-nav").style.display = 'block'
     }


### PR DESCRIPTION
### Done in this PR
Hide the navigation item in the federated documentation for the portals that doesn't have a specific page in this page.

### Demo
[Capture vidéo du 06-05-2024 15:35:00.webm](https://github.com/ontoportal-lirmm/documentation/assets/61744974/10b6b8bc-17e5-4635-87eb-ff03f0c00619)
